### PR TITLE
change to info to grab user name and email from connection params

### DIFF
--- a/lib/ueberauth/strategy/apple.ex
+++ b/lib/ueberauth/strategy/apple.ex
@@ -99,15 +99,22 @@ defmodule Ueberauth.Strategy.Apple do
   @doc """
   Fetches the fields to populate the info section of the `Ueberauth.Auth` struct.
   """
-  def info(conn) do
-    user = conn.private.apple_user
-    name = user["name"]
+  def info(%Plug.Conn{params: %{"user" => userblob}} = conn) do
+    case Poison.decode(userblob) do
+      {:ok, user} ->
+        %Info{
+          email: user["email"],
+          first_name: user["name"]["firstName"],
+          last_name: user["name"]["lastName"]
+        }
 
-    %Info{
-      email: user["email"],
-      first_name: name && name["firstName"],
-      last_name: name && name["lastName"]
-    }
+      {:error, message} ->
+        %Info{}
+    end
+  end
+
+  def info(conn) do
+    %Info{}
   end
 
   @doc """


### PR DESCRIPTION
Ueberauth_apple is working great for us but we had to make a change to get the user name and email out of the POST parameters (should be the same for GET but we haven't tested)

Wanted to make an upstream PR in case this was helpfull,

All the best,

Clover Food Labs