### PR TITLE
Add Serializer

### DIFF
--- a/lib/ueberauth/strategy/apple/oauth.ex
+++ b/lib/ueberauth/strategy/apple/oauth.ex
@@ -34,7 +34,10 @@ defmodule Ueberauth.Strategy.Apple.OAuth do
       |> resolve_values()
       |> generate_secret()
 
+    json_library = Ueberauth.json_library()
+
     OAuth2.Client.new(opts)
+    |> OAuth2.Client.put_serializer("application/json", json_library)
   end
 
   @doc """


### PR DESCRIPTION
The latest ueberauth version doesn't serialize the response body and therefore the access token isn't extracted correctly.

