### PR TITLE
Add httpoison runtime dependency

### DIFF
--- a/lib/ueberauth/strategy/apple.ex
+++ b/lib/ueberauth/strategy/apple.ex
@@ -1,6 +1,6 @@
 defmodule Ueberauth.Strategy.Apple do
   @moduledoc """
-  Google Strategy for Überauth.
+  Apple Strategy for Überauth.
   """
 
   use Ueberauth.Strategy, uid_field: :uid, default_scope: "name email"
@@ -111,7 +111,7 @@ defmodule Ueberauth.Strategy.Apple do
   end
 
   @doc """
-  Stores the raw information (including the token) obtained from the google callback.
+  Stores the raw information (including the token) obtained from the apple callback.
   """
   def extra(conn) do
     %Extra{

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule UeberauthApple.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :oauth2, :ueberauth]]
+    [applications: [:logger, :oauth2, :ueberauth, :httpoison, :jose]]
   end
 
   defp deps do


### PR DESCRIPTION
This adds `httpoison` and `jose` as dependent runtime applications - they are accessed in `UeberauthApple.uid_from_id_token/1`.

Without this explicit application dependency they might not get included in the release of a runtime dependencies of of an app that's using `ueberauth_apple`.

(it also fixes two copy&paste artifacts in comments 🧹)