### PR TITLE
Fetch user email from id_token

### DIFF
--- a/lib/ueberauth/strategy/apple.ex
+++ b/lib/ueberauth/strategy/apple.ex
@@ -37,8 +37,12 @@ defmodule Ueberauth.Strategy.Apple do
 
     case Ueberauth.Strategy.Apple.OAuth.get_access_token([code: code], opts) do
       {:ok, token} ->
+        %{"email" => user_email, "sub" => user_uid} = UeberauthApple.id_token_payload(token.other_params["id_token"])
+
         apple_user =
-          Map.put(user, "uid", UeberauthApple.uid_from_id_token(token.other_params["id_token"]))
+          user
+          |> Map.put("uid", user_uid)
+          |> Map.put("email", user_email)
 
         conn
         |> put_private(:apple_token, token)

--- a/lib/ueberauth_apple.ex
+++ b/lib/ueberauth_apple.ex
@@ -2,12 +2,11 @@ defmodule UeberauthApple do
   @default_expires_in 86400 * 180
   @public_key_url "https://appleid.apple.com/auth/keys"
 
-  def uid_from_id_token(id_token) do
+  def id_token_payload(id_token) do
     with keys <- fetch_public_keys(),
          key <- get_appropriate_key(keys, id_token),
-         {true, %JOSE.JWT{fields: fields}, _JWS} <- JOSE.JWT.verify(key, id_token),
-         {:ok, uid} <- {:ok, fields["sub"]} do
-      uid
+         {true, %JOSE.JWT{fields: fields}, _JWS} <- JOSE.JWT.verify(key, id_token) do
+      fields
     end
   end
 


### PR DESCRIPTION
This adds support for the inconsistent Apple oauth account email handling.
Depending on whether an Apple user signed up for an app previously or it is the first sign up the email is in different places of the response.
As mentioned [in the API docs](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple#3383768) "Apple provides the user’s email address in the identity token on all subsequent API responses" - while the `email` + `name` are only included plainly in the response params of the first signup request (that's where `ueberauth_apple` fetches them from right now).

This can lead to weird behaviour, e.g. when the first signup response is not received due to network issues - in order to give a more consistent experience, this PR sets the `email` from the `id_token` as well.